### PR TITLE
feat(pods): pods_exec supports specifying container

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ Execute a command in a Kubernetes Pod in the current or provided namespace with 
   - Name of the Pod
 - `namespace` (string, required)
   - Namespace of the Pod
+- `container` (`string`, optional)
+  - Name of the Pod container to get logs from
 
 ### `pods_get`
 

--- a/pkg/kubernetes/pods.go
+++ b/pkg/kubernetes/pods.go
@@ -184,17 +184,18 @@ func (k *Kubernetes) PodsExec(ctx context.Context, namespace, name, container st
 	if pod.Status.Phase == v1.PodSucceeded || pod.Status.Phase == v1.PodFailed {
 		return "", fmt.Errorf("cannot exec into a container in a completed pod; current phase is %s", pod.Status.Phase)
 	}
+	if container == "" {
+		container = pod.Spec.Containers[0].Name
+	}
 	podExecOptions := &v1.PodExecOptions{
-		Command: command,
-		Stdout:  true,
-		Stderr:  true,
+		Container: container,
+		Command:   command,
+		Stdout:    true,
+		Stderr:    true,
 	}
 	executor, err := k.createExecutor(namespace, name, podExecOptions)
 	if err != nil {
 		return "", err
-	}
-	if container == "" {
-		container = pod.Spec.Containers[0].Name
 	}
 	stdout := bytes.NewBuffer(make([]byte, 0))
 	stderr := bytes.NewBuffer(make([]byte, 0))


### PR DESCRIPTION
Fixes #56

Allows to specify the container where the command will be executed. Additionally, prevents the command from failing in pods with multiple containers when the container is not specified (defaults to first).