### PR TITLE
feat(auth)!: use generic kubernetes-authorization header

### DIFF
--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -109,6 +109,5 @@ func NewTextResult(content string, err error) *mcp.CallToolResult {
 }
 
 func contextFunc(ctx context.Context, r *http.Request) context.Context {
-	//return context.WithValue(ctx, kubernetes.AuthorizationHeader, r.Header.Get(kubernetes.AuthorizationHeader))
-	return context.WithValue(ctx, kubernetes.AuthorizationBearerTokenHeader, r.Header.Get(kubernetes.AuthorizationBearerTokenHeader))
+	return context.WithValue(ctx, kubernetes.AuthorizationHeader, r.Header.Get(kubernetes.AuthorizationHeader))
 }

--- a/pkg/mcp/mcp_test.go
+++ b/pkg/mcp/mcp_test.go
@@ -96,7 +96,7 @@ func TestSseHeaders(t *testing.T) {
 	defer mockServer.Close()
 	before := func(c *mcpContext) {
 		c.withKubeConfig(mockServer.config)
-		c.clientOptions = append(c.clientOptions, client.WithHeaders(map[string]string{"kubernetes-authorization-bearer-token": "a-token-from-mcp-client"}))
+		c.clientOptions = append(c.clientOptions, client.WithHeaders(map[string]string{"kubernetes-authorization": "Bearer a-token-from-mcp-client"}))
 	}
 	pathHeaders := make(map[string]http.Header, 0)
 	mockServer.Handle(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
Relates to https://github.com/openshift/lightspeed-service/pull/2536