### PR TITLE
Use built-in ptr.Deref instead of a custom func

### DIFF
--- a/pkg/mcp/configuration.go
+++ b/pkg/mcp/configuration.go
@@ -3,9 +3,11 @@ package mcp
 import (
 	"context"
 	"fmt"
-	"github.com/manusa/kubernetes-mcp-server/pkg/output"
+
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/manusa/kubernetes-mcp-server/pkg/output"
 )
 
 func (s *Server) initConfiguration() []server.ServerTool {

--- a/pkg/mcp/events.go
+++ b/pkg/mcp/events.go
@@ -3,9 +3,11 @@ package mcp
 import (
 	"context"
 	"fmt"
-	"github.com/manusa/kubernetes-mcp-server/pkg/output"
+
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/manusa/kubernetes-mcp-server/pkg/output"
 )
 
 func (s *Server) initEvents() []server.ServerTool {

--- a/pkg/mcp/helm.go
+++ b/pkg/mcp/helm.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"fmt"
+
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 )

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -2,12 +2,15 @@ package mcp
 
 import (
 	"context"
+	"net/http"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"k8s.io/utils/ptr"
+
 	"github.com/manusa/kubernetes-mcp-server/pkg/kubernetes"
 	"github.com/manusa/kubernetes-mcp-server/pkg/output"
 	"github.com/manusa/kubernetes-mcp-server/pkg/version"
-	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/mark3labs/mcp-go/server"
-	"net/http"
 )
 
 type Configuration struct {
@@ -45,10 +48,6 @@ func NewSever(configuration Configuration) (*Server, error) {
 	return s, nil
 }
 
-func isFalse(value *bool) bool {
-	return value == nil || !*value
-}
-
 func (s *Server) reloadKubernetesClient() error {
 	k, err := kubernetes.NewKubernetes(s.configuration.Kubeconfig)
 	if err != nil {
@@ -57,10 +56,10 @@ func (s *Server) reloadKubernetesClient() error {
 	s.k = k
 	applicableTools := make([]server.ServerTool, 0)
 	for _, tool := range s.configuration.Profile.GetTools(s) {
-		if s.configuration.ReadOnly && isFalse(tool.Tool.Annotations.ReadOnlyHint) {
+		if s.configuration.ReadOnly && !ptr.Deref(tool.Tool.Annotations.ReadOnlyHint, false) {
 			continue
 		}
-		if s.configuration.DisableDestructive && isFalse(tool.Tool.Annotations.ReadOnlyHint) && !isFalse(tool.Tool.Annotations.DestructiveHint) {
+		if s.configuration.DisableDestructive && !ptr.Deref(tool.Tool.Annotations.ReadOnlyHint, false) && ptr.Deref(tool.Tool.Annotations.DestructiveHint, false) {
 			continue
 		}
 		applicableTools = append(applicableTools, tool)

--- a/pkg/mcp/namespaces.go
+++ b/pkg/mcp/namespaces.go
@@ -3,9 +3,11 @@ package mcp
 import (
 	"context"
 	"fmt"
-	"github.com/manusa/kubernetes-mcp-server/pkg/kubernetes"
+
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/manusa/kubernetes-mcp-server/pkg/kubernetes"
 )
 
 func (s *Server) initNamespaces() []server.ServerTool {

--- a/pkg/mcp/pods.go
+++ b/pkg/mcp/pods.go
@@ -5,12 +5,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/manusa/kubernetes-mcp-server/pkg/kubernetes"
-	"github.com/manusa/kubernetes-mcp-server/pkg/output"
-	"k8s.io/kubectl/pkg/metricsutil"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	"k8s.io/kubectl/pkg/metricsutil"
+
+	"github.com/manusa/kubernetes-mcp-server/pkg/kubernetes"
+	"github.com/manusa/kubernetes-mcp-server/pkg/output"
 )
 
 func (s *Server) initPods() []server.ServerTool {

--- a/pkg/mcp/profiles.go
+++ b/pkg/mcp/profiles.go
@@ -1,8 +1,9 @@
 package mcp
 
 import (
-	"github.com/mark3labs/mcp-go/server"
 	"slices"
+
+	"github.com/mark3labs/mcp-go/server"
 )
 
 type Profile interface {

--- a/pkg/mcp/resources.go
+++ b/pkg/mcp/resources.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/manusa/kubernetes-mcp-server/pkg/kubernetes"
-	"github.com/manusa/kubernetes-mcp-server/pkg/output"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/manusa/kubernetes-mcp-server/pkg/kubernetes"
+	"github.com/manusa/kubernetes-mcp-server/pkg/output"
 )
 
 func (s *Server) initResources() []server.ServerTool {

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -2,6 +2,7 @@ package output
 
 import (
 	"bytes"
+	
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"


### PR DESCRIPTION
Trivial changes to use `ptr.Deref` and reorganizing go imports.