### PR TITLE
Introduce toml configuration file with a set of deny list

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/manusa/kubernetes-mcp-server
 go 1.24.1
 
 require (
+	github.com/BurntSushi/toml v1.5.0
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/mark3labs/mcp-go v0.32.0
 	github.com/pkg/errors v0.9.1
@@ -28,7 +29,6 @@ require (
 require (
 	dario.cat/mergo v1.0.1 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
-	github.com/BurntSushi/toml v1.5.0 // indirect
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.3.0 // indirect

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,31 @@
+package config
+
+import (
+	"os"
+
+	"github.com/BurntSushi/toml"
+)
+
+type StaticConfig struct {
+	DeniedResources []GroupVersionKind `toml:"denied_resources"`
+}
+
+type GroupVersionKind struct {
+	Group   string `toml:"group"`
+	Version string `toml:"version"`
+	Kind    string `toml:"kind,omitempty"`
+}
+
+func ReadConfig(configPath string) (*StaticConfig, error) {
+	configData, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var config *StaticConfig
+	err = toml.Unmarshal(configData, &config)
+	if err != nil {
+		return nil, err
+	}
+	return config, nil
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,48 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadConfig(t *testing.T) {
+	tempDir := t.TempDir()
+
+	t.Run("ValidConfigFileWithDeniedResources", func(t *testing.T) {
+		validConfigContent := `
+[[denied_resources]]
+group = "apps"
+version = "v1"
+kind = "Deployment"
+
+[[denied_resources]]
+group = "rbac.authorization.k8s.io"
+version = "v1"
+`
+		validConfigPath := filepath.Join(tempDir, "valid_denied_config.toml")
+		err := os.WriteFile(validConfigPath, []byte(validConfigContent), 0644)
+		if err != nil {
+			t.Fatalf("Failed to write valid config file: %v", err)
+		}
+
+		config, err := ReadConfig(validConfigPath)
+		if err != nil {
+			t.Fatalf("ReadConfig returned an error for a valid file: %v", err)
+		}
+
+		if config == nil {
+			t.Fatal("ReadConfig returned a nil config for a valid file")
+		}
+
+		if len(config.DeniedResources) != 2 {
+			t.Fatalf("Expected 2 denied resources, got %d", len(config.DeniedResources))
+		}
+
+		if config.DeniedResources[0].Group != "apps" ||
+			config.DeniedResources[0].Version != "v1" ||
+			config.DeniedResources[0].Kind != "Deployment" {
+			t.Errorf("Unexpected denied resources: %v", config.DeniedResources[0])
+		}
+	})
+}

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -2,8 +2,10 @@ package kubernetes
 
 import (
 	"context"
+	"strings"
+
 	"github.com/fsnotify/fsnotify"
-	"github.com/manusa/kubernetes-mcp-server/pkg/helm"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -11,13 +13,16 @@ import (
 	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
-	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/klog/v2"
-	"strings"
+
+	"github.com/manusa/kubernetes-mcp-server/pkg/config"
+	"github.com/manusa/kubernetes-mcp-server/pkg/helm"
+
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 )
 
 const (
@@ -42,11 +47,14 @@ type Manager struct {
 	discoveryClient             discovery.CachedDiscoveryInterface
 	deferredDiscoveryRESTMapper *restmapper.DeferredDiscoveryRESTMapper
 	dynamicClient               *dynamic.DynamicClient
+
+	StaticConfig *config.StaticConfig
 }
 
-func NewManager(kubeconfig string) (*Manager, error) {
+func NewManager(kubeconfig string, config *config.StaticConfig) (*Manager, error) {
 	k8s := &Manager{
-		Kubeconfig: kubeconfig,
+		Kubeconfig:   kubeconfig,
+		StaticConfig: config,
 	}
 	if err := resolveKubernetesConfigurations(k8s); err != nil {
 		return nil, err

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"github.com/manusa/kubernetes-mcp-server/pkg/config"
 	"net/http"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -21,6 +22,8 @@ type Configuration struct {
 	// When true, disable tools annotated with destructiveHint=true
 	DisableDestructive bool
 	Kubeconfig         string
+
+	StaticConfig *config.StaticConfig
 }
 
 type Server struct {
@@ -29,7 +32,7 @@ type Server struct {
 	k             *kubernetes.Manager
 }
 
-func NewSever(configuration Configuration) (*Server, error) {
+func NewServer(configuration Configuration) (*Server, error) {
 	s := &Server{
 		configuration: &configuration,
 		server: server.NewMCPServer(
@@ -45,11 +48,12 @@ func NewSever(configuration Configuration) (*Server, error) {
 		return nil, err
 	}
 	s.k.WatchKubeConfig(s.reloadKubernetesClient)
+
 	return s, nil
 }
 
 func (s *Server) reloadKubernetesClient() error {
-	k, err := kubernetes.NewManager(s.configuration.Kubeconfig)
+	k, err := kubernetes.NewManager(s.configuration.Kubeconfig, s.configuration.StaticConfig)
 	if err != nil {
 		return err
 	}

--- a/pkg/mcp/mcp_test.go
+++ b/pkg/mcp/mcp_test.go
@@ -2,14 +2,17 @@ package mcp
 
 import (
 	"context"
-	"github.com/mark3labs/mcp-go/client"
-	"github.com/mark3labs/mcp-go/mcp"
 	"net/http"
 	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
 	"time"
+
+	"github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/manusa/kubernetes-mcp-server/pkg/config"
 )
 
 func TestWatchKubeConfig(t *testing.T) {
@@ -96,6 +99,7 @@ func TestSseHeaders(t *testing.T) {
 	defer mockServer.Close()
 	before := func(c *mcpContext) {
 		c.withKubeConfig(mockServer.config)
+		c.withStaticConfig(&config.StaticConfig{})
 		c.clientOptions = append(c.clientOptions, client.WithHeaders(map[string]string{"kubernetes-authorization": "Bearer a-token-from-mcp-client"}))
 	}
 	pathHeaders := make(map[string]http.Header, 0)

--- a/pkg/mcp/resources_test.go
+++ b/pkg/mcp/resources_test.go
@@ -54,6 +54,26 @@ func TestResourcesList(t *testing.T) {
 				t.Fatalf("invalid error message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
 			}
 		})
+		t.Run("resources_list with a resource in denied list as kind", func(t *testing.T) {
+			toolResult, _ := c.callTool("resources_list", map[string]interface{}{"apiVersion": "v1", "kind": "Secret"})
+			if !toolResult.IsError {
+				t.Fatalf("call tool should fail")
+			}
+			//failed to list resources: resource not allowed: /v1, Kind=Secret
+			if toolResult.Content[0].(mcp.TextContent).Text != `failed to list resources: resource not allowed: /v1, Kind=Secret` {
+				t.Fatalf("invalid error message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+			}
+		})
+		t.Run("resources_list with a resource in denied list as group", func(t *testing.T) {
+			toolResult, _ := c.callTool("resources_list", map[string]interface{}{"apiVersion": "rbac.authorization.k8s.io/v1", "kind": "Role"})
+			if !toolResult.IsError {
+				t.Fatalf("call tool should fail")
+			}
+			//failed to list resources: resource not allowed: /v1, Kind=Secret
+			if toolResult.Content[0].(mcp.TextContent).Text != `failed to list resources: resource not allowed: rbac.authorization.k8s.io/v1, Kind=Role` {
+				t.Fatalf("invalid error message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+			}
+		})
 		namespaces, err := c.callTool("resources_list", map[string]interface{}{"apiVersion": "v1", "kind": "Namespace"})
 		t.Run("resources_list returns namespaces", func(t *testing.T) {
 			if err != nil {

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -2,7 +2,7 @@ package output
 
 import (
 	"bytes"
-	
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"


### PR DESCRIPTION
Fixes #131 
Introduces PoC for #132 

This PR introduces a new static configuration file in toml format that defaults to `conf.toml` but can be modified via flag `config`. 

Additionally, this PR adds predefined set of resources to not allow any operations in MCP Server.

This PR is supposed to fix https://github.com/manusa/kubernetes-mcp-server/issues/132 and https://github.com/manusa/kubernetes-mcp-server/issues/131