### PR TITLE
feat(config): deny resources by using RESTMapper as an interceptor

### DIFF
--- a/pkg/kubernetes/accesscontrol.go
+++ b/pkg/kubernetes/accesscontrol.go
@@ -1,0 +1,40 @@
+package kubernetes
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/manusa/kubernetes-mcp-server/pkg/config"
+)
+
+// isAllowed checks the resource is in denied list or not.
+// If it is in denied list, this function returns false.
+func isAllowed(
+	staticConfig *config.StaticConfig, // TODO: maybe just use the denied resource slice
+	gvk *schema.GroupVersionKind,
+) bool {
+	if staticConfig == nil {
+		return true
+	}
+
+	for _, val := range staticConfig.DeniedResources {
+		// If kind is empty, that means Group/Version pair is denied entirely
+		if val.Kind == "" {
+			if gvk.Group == val.Group && gvk.Version == val.Version {
+				return false
+			}
+		}
+		if gvk.Group == val.Group &&
+			gvk.Version == val.Version &&
+			gvk.Kind == val.Kind {
+			return false
+		}
+	}
+
+	return true
+}
+
+func isNotAllowedError(gvk *schema.GroupVersionKind) error {
+	return fmt.Errorf("resource not allowed: %s", gvk.String())
+}

--- a/pkg/kubernetes/accesscontrol_clientset.go
+++ b/pkg/kubernetes/accesscontrol_clientset.go
@@ -1,0 +1,74 @@
+package kubernetes
+
+import (
+	authorizationv1api "k8s.io/api/authorization/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/kubernetes"
+	authorizationv1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
+
+	"github.com/manusa/kubernetes-mcp-server/pkg/config"
+)
+
+// AccessControlClientset is a limited clientset delegating interface to the standard kubernetes.Clientset
+// Only a limited set of functions are implemented with a single point of access to the kubernetes API where
+// apiVersion and kinds are checked for allowed access
+type AccessControlClientset struct {
+	delegate        kubernetes.Interface
+	discoveryClient discovery.DiscoveryInterface
+	staticConfig    *config.StaticConfig // TODO: maybe just store the denied resource slice
+}
+
+func (a *AccessControlClientset) DiscoveryClient() discovery.DiscoveryInterface {
+	return a.discoveryClient
+}
+
+func (a *AccessControlClientset) Pods(namespace string) (corev1.PodInterface, error) {
+	gvk := &schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}
+	if !isAllowed(a.staticConfig, gvk) {
+		return nil, isNotAllowedError(gvk)
+	}
+	return a.delegate.CoreV1().Pods(namespace), nil
+}
+
+func (a *AccessControlClientset) PodsExec(namespace, name string) (*rest.Request, error) {
+	gvk := &schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}
+	if !isAllowed(a.staticConfig, gvk) {
+		return nil, isNotAllowedError(gvk)
+	}
+	// https://github.com/kubernetes/kubectl/blob/5366de04e168bcbc11f5e340d131a9ca8b7d0df4/pkg/cmd/exec/exec.go#L382-L397
+	return a.delegate.CoreV1().RESTClient().
+		Post().
+		Resource("pods").
+		Namespace(namespace).
+		Name(name).
+		SubResource("exec"), nil
+}
+
+func (a *AccessControlClientset) Services(namespace string) (corev1.ServiceInterface, error) {
+	gvk := &schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Service"}
+	if !isAllowed(a.staticConfig, gvk) {
+		return nil, isNotAllowedError(gvk)
+	}
+	return a.delegate.CoreV1().Services(namespace), nil
+}
+
+func (a *AccessControlClientset) SelfSubjectAccessReviews() (authorizationv1.SelfSubjectAccessReviewInterface, error) {
+	gvk := &schema.GroupVersionKind{Group: authorizationv1api.GroupName, Version: authorizationv1api.SchemeGroupVersion.Version, Kind: "SelfSubjectAccessReview"}
+	if !isAllowed(a.staticConfig, gvk) {
+		return nil, isNotAllowedError(gvk)
+	}
+	return a.delegate.AuthorizationV1().SelfSubjectAccessReviews(), nil
+}
+
+func NewAccessControlClientset(cfg *rest.Config, staticConfig *config.StaticConfig) (*AccessControlClientset, error) {
+	clientSet, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return &AccessControlClientset{
+		delegate: clientSet, discoveryClient: clientSet.DiscoveryClient, staticConfig: staticConfig,
+	}, nil
+}

--- a/pkg/kubernetes/accesscontrol_restmapper.go
+++ b/pkg/kubernetes/accesscontrol_restmapper.go
@@ -1,0 +1,106 @@
+package kubernetes
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/restmapper"
+
+	"github.com/manusa/kubernetes-mcp-server/pkg/config"
+)
+
+type AccessControlRESTMapper struct {
+	delegate     *restmapper.DeferredDiscoveryRESTMapper
+	staticConfig *config.StaticConfig // TODO: maybe just store the denied resource slice
+}
+
+var _ meta.RESTMapper = &AccessControlRESTMapper{}
+
+// isAllowed checks the resource is in denied list or not.
+// If it is in denied list, this function returns false.
+func (a AccessControlRESTMapper) isAllowed(gvk *schema.GroupVersionKind) bool {
+	if a.staticConfig == nil {
+		return true
+	}
+
+	for _, val := range a.staticConfig.DeniedResources {
+		// If kind is empty, that means Group/Version pair is denied entirely
+		if val.Kind == "" {
+			if gvk.Group == val.Group && gvk.Version == val.Version {
+				return false
+			}
+		}
+		if gvk.Group == val.Group &&
+			gvk.Version == val.Version &&
+			gvk.Kind == val.Kind {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (a AccessControlRESTMapper) KindFor(resource schema.GroupVersionResource) (schema.GroupVersionKind, error) {
+	gvk, err := a.delegate.KindFor(resource)
+	if err != nil {
+		return schema.GroupVersionKind{}, err
+	}
+	if !a.isAllowed(&gvk) {
+		return schema.GroupVersionKind{}, fmt.Errorf("resource not allowed: %s", gvk.String())
+	}
+	return gvk, nil
+}
+
+func (a AccessControlRESTMapper) KindsFor(resource schema.GroupVersionResource) ([]schema.GroupVersionKind, error) {
+	gvks, err := a.delegate.KindsFor(resource)
+	if err != nil {
+		return nil, err
+	}
+	for i := range gvks {
+		if !a.isAllowed(&gvks[i]) {
+			return nil, fmt.Errorf("resource not allowed: %s", gvks[i].String())
+		}
+	}
+	return gvks, nil
+}
+
+func (a AccessControlRESTMapper) ResourceFor(input schema.GroupVersionResource) (schema.GroupVersionResource, error) {
+	return a.delegate.ResourceFor(input)
+}
+
+func (a AccessControlRESTMapper) ResourcesFor(input schema.GroupVersionResource) ([]schema.GroupVersionResource, error) {
+	return a.delegate.ResourcesFor(input)
+}
+
+func (a AccessControlRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*meta.RESTMapping, error) {
+	for _, version := range versions {
+		gvk := &schema.GroupVersionKind{Group: gk.Group, Version: version, Kind: gk.Kind}
+		if !a.isAllowed(gvk) {
+			return nil, fmt.Errorf("resource not allowed: %s", gvk.String())
+		}
+	}
+	return a.delegate.RESTMapping(gk, versions...)
+}
+
+func (a AccessControlRESTMapper) RESTMappings(gk schema.GroupKind, versions ...string) ([]*meta.RESTMapping, error) {
+	for _, version := range versions {
+		gvk := &schema.GroupVersionKind{Group: gk.Group, Version: version, Kind: gk.Kind}
+		if !a.isAllowed(gvk) {
+			return nil, fmt.Errorf("resource not allowed: %s", gvk.String())
+		}
+	}
+	return a.delegate.RESTMappings(gk, versions...)
+}
+
+func (a AccessControlRESTMapper) ResourceSingularizer(resource string) (singular string, err error) {
+	return a.delegate.ResourceSingularizer(resource)
+}
+
+func (a AccessControlRESTMapper) Reset() {
+	a.delegate.Reset()
+}
+
+func NewAccessControlRESTMapper(delegate *restmapper.DeferredDiscoveryRESTMapper, staticConfig *config.StaticConfig) *AccessControlRESTMapper {
+	return &AccessControlRESTMapper{delegate: delegate, staticConfig: staticConfig}
+}

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -12,7 +12,6 @@ import (
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/dynamic"
-	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/clientcmd"
@@ -21,6 +20,8 @@ import (
 
 	"github.com/manusa/kubernetes-mcp-server/pkg/config"
 	"github.com/manusa/kubernetes-mcp-server/pkg/helm"
+
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 )
 
 const (

--- a/pkg/kubernetes/resources.go
+++ b/pkg/kubernetes/resources.go
@@ -109,7 +109,7 @@ func (k *Kubernetes) resourcesListAsTable(ctx context.Context, gvk *schema.Group
 			"application/json",
 		}, ",")).
 		AbsPath(url...).
-		SpecificallyVersionedParams(&options.ListOptions, k.manager.parameterCodec, schema.GroupVersion{Version: "v1"}).
+		SpecificallyVersionedParams(&options.ListOptions, ParameterCodec, schema.GroupVersion{Version: "v1"}).
 		Do(ctx).Into(&table)
 	if err != nil {
 		return nil, err

--- a/pkg/mcp/events_test.go
+++ b/pkg/mcp/events_test.go
@@ -108,7 +108,7 @@ func TestEventsListDenied(t *testing.T) {
 		t.Run("events_list describes denial", func(t *testing.T) {
 			expectedMessage := "failed to list events in all namespaces: resource not allowed: /v1, Kind=Event"
 			if eventList.Content[0].(mcp.TextContent).Text != expectedMessage {
-				t.Fatalf("expected desciptive error '%s', got %v", expectedMessage, eventList.Content[0].(mcp.TextContent).Text)
+				t.Fatalf("expected descriptive error '%s', got %v", expectedMessage, eventList.Content[0].(mcp.TextContent).Text)
 			}
 		})
 	})

--- a/pkg/mcp/helm_test.go
+++ b/pkg/mcp/helm_test.go
@@ -59,7 +59,6 @@ func TestHelmInstall(t *testing.T) {
 }
 
 func TestHelmInstallDenied(t *testing.T) {
-	t.Skip("To be implemented") // TODO: helm_install is not checking for denied resources
 	deniedResourcesServer := &config.StaticConfig{DeniedResources: []config.GroupVersionKind{{Version: "v1", Kind: "Secret"}}}
 	testCaseWithContext(t, &mcpContext{staticConfig: deniedResourcesServer}, func(c *mcpContext) {
 		c.withEnvTest()
@@ -74,9 +73,10 @@ func TestHelmInstallDenied(t *testing.T) {
 			}
 		})
 		t.Run("helm_install describes denial", func(t *testing.T) {
-			expectedMessage := "failed to install helm chart: resource not allowed: /v1, Kind=Secret"
-			if helmInstall.Content[0].(mcp.TextContent).Text != expectedMessage {
-				t.Fatalf("expected desciptive error '%s', got %v", expectedMessage, helmInstall.Content[0].(mcp.TextContent).Text)
+			toolOutput := helmInstall.Content[0].(mcp.TextContent).Text
+			expectedMessage := ": resource not allowed: /v1, Kind=Secret"
+			if !strings.HasPrefix(toolOutput, "failed to install helm chart") || !strings.HasSuffix(toolOutput, expectedMessage) {
+				t.Fatalf("expected descriptive error '%s', got %v", expectedMessage, helmInstall.Content[0].(mcp.TextContent).Text)
 			}
 		})
 	})

--- a/pkg/mcp/helm_test.go
+++ b/pkg/mcp/helm_test.go
@@ -225,7 +225,33 @@ func TestHelmUninstall(t *testing.T) {
 }
 
 func TestHelmUninstallDenied(t *testing.T) {
-	t.Skip("To be implemented") // TODO: helm_uninstall is not checking for denied resources
+	deniedResourcesServer := &config.StaticConfig{DeniedResources: []config.GroupVersionKind{{Version: "v1", Kind: "Secret"}}}
+	testCaseWithContext(t, &mcpContext{staticConfig: deniedResourcesServer}, func(c *mcpContext) {
+		c.withEnvTest()
+		kc := c.newKubernetesClient()
+		clearHelmReleases(c.ctx, kc)
+		_, _ = kc.CoreV1().Secrets("default").Create(c.ctx, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "sh.helm.release.v1.existent-release-to-uninstall.v0",
+				Labels: map[string]string{"owner": "helm", "name": "existent-release-to-uninstall"},
+			},
+			Data: map[string][]byte{
+				"release": []byte(base64.StdEncoding.EncodeToString([]byte("{" +
+					"\"name\":\"existent-release-to-uninstall\"," +
+					"\"info\":{\"status\":\"deployed\"}," +
+					"\"manifest\":\"apiVersion: v1\\nkind: Secret\\nmetadata:\\n  name: secret-to-deny\\n  namespace: default\\n\"" +
+					"}"))),
+			},
+		}, metav1.CreateOptions{})
+		helmUninstall, _ := c.callTool("helm_uninstall", map[string]interface{}{
+			"name": "existent-release-to-uninstall",
+		})
+		t.Run("helm_uninstall has error", func(t *testing.T) {
+			if !helmUninstall.IsError {
+				t.Fatalf("call tool should fail")
+			}
+		})
+	})
 }
 
 func clearHelmReleases(ctx context.Context, kc *kubernetes.Clientset) {

--- a/pkg/mcp/namespaces_test.go
+++ b/pkg/mcp/namespaces_test.go
@@ -62,7 +62,7 @@ func TestNamespacesListDenied(t *testing.T) {
 		t.Run("namespaces_list describes denial", func(t *testing.T) {
 			expectedMessage := "failed to list namespaces: resource not allowed: /v1, Kind=Namespace"
 			if namespacesList.Content[0].(mcp.TextContent).Text != expectedMessage {
-				t.Fatalf("expected desciptive error '%s', got %v", expectedMessage, namespacesList.Content[0].(mcp.TextContent).Text)
+				t.Fatalf("expected descriptive error '%s', got %v", expectedMessage, namespacesList.Content[0].(mcp.TextContent).Text)
 			}
 		})
 	})
@@ -167,7 +167,7 @@ func TestProjectsListInOpenShiftDenied(t *testing.T) {
 		t.Run("projects_list describes denial", func(t *testing.T) {
 			expectedMessage := "failed to list projects: resource not allowed: project.openshift.io/v1, Kind=Project"
 			if projectsList.Content[0].(mcp.TextContent).Text != expectedMessage {
-				t.Fatalf("expected desciptive error '%s', got %v", expectedMessage, projectsList.Content[0].(mcp.TextContent).Text)
+				t.Fatalf("expected descriptive error '%s', got %v", expectedMessage, projectsList.Content[0].(mcp.TextContent).Text)
 			}
 		})
 	})

--- a/pkg/mcp/pods_test.go
+++ b/pkg/mcp/pods_test.go
@@ -190,7 +190,7 @@ func TestPodsListDenied(t *testing.T) {
 		t.Run("pods_list describes denial", func(t *testing.T) {
 			expectedMessage := "failed to list pods in all namespaces: resource not allowed: /v1, Kind=Pod"
 			if podsList.Content[0].(mcp.TextContent).Text != expectedMessage {
-				t.Fatalf("expected desciptive error '%s', got %v", expectedMessage, podsList.Content[0].(mcp.TextContent).Text)
+				t.Fatalf("expected descriptive error '%s', got %v", expectedMessage, podsList.Content[0].(mcp.TextContent).Text)
 			}
 		})
 		podsListInNamespace, _ := c.callTool("pods_list_in_namespace", map[string]interface{}{"namespace": "ns-1"})
@@ -202,7 +202,7 @@ func TestPodsListDenied(t *testing.T) {
 		t.Run("pods_list_in_namespace describes denial", func(t *testing.T) {
 			expectedMessage := "failed to list pods in namespace ns-1: resource not allowed: /v1, Kind=Pod"
 			if podsListInNamespace.Content[0].(mcp.TextContent).Text != expectedMessage {
-				t.Fatalf("expected desciptive error '%s', got %v", expectedMessage, podsListInNamespace.Content[0].(mcp.TextContent).Text)
+				t.Fatalf("expected descriptive error '%s', got %v", expectedMessage, podsListInNamespace.Content[0].(mcp.TextContent).Text)
 			}
 		})
 	})
@@ -425,7 +425,7 @@ func TestPodsGetDenied(t *testing.T) {
 		t.Run("pods_get describes denial", func(t *testing.T) {
 			expectedMessage := "failed to get pod a-pod-in-default in namespace : resource not allowed: /v1, Kind=Pod"
 			if podsGet.Content[0].(mcp.TextContent).Text != expectedMessage {
-				t.Fatalf("expected desciptive error '%s', got %v", expectedMessage, podsGet.Content[0].(mcp.TextContent).Text)
+				t.Fatalf("expected descriptive error '%s', got %v", expectedMessage, podsGet.Content[0].(mcp.TextContent).Text)
 			}
 		})
 	})
@@ -576,7 +576,7 @@ func TestPodsDeleteDenied(t *testing.T) {
 		t.Run("pods_delete describes denial", func(t *testing.T) {
 			expectedMessage := "failed to delete pod a-pod-in-default in namespace : resource not allowed: /v1, Kind=Pod"
 			if podsDelete.Content[0].(mcp.TextContent).Text != expectedMessage {
-				t.Fatalf("expected desciptive error '%s', got %v", expectedMessage, podsDelete.Content[0].(mcp.TextContent).Text)
+				t.Fatalf("expected descriptive error '%s', got %v", expectedMessage, podsDelete.Content[0].(mcp.TextContent).Text)
 			}
 		})
 	})
@@ -736,7 +736,7 @@ func TestPodsLogDenied(t *testing.T) {
 		t.Run("pods_log describes denial", func(t *testing.T) {
 			expectedMessage := "failed to log pod a-pod-in-default in namespace : resource not allowed: /v1, Kind=Pod"
 			if podsLog.Content[0].(mcp.TextContent).Text != expectedMessage {
-				t.Fatalf("expected desciptive error '%s', got %v", expectedMessage, podsLog.Content[0].(mcp.TextContent).Text)
+				t.Fatalf("expected descriptive error '%s', got %v", expectedMessage, podsLog.Content[0].(mcp.TextContent).Text)
 			}
 		})
 	})
@@ -905,7 +905,7 @@ func TestPodsRunDenied(t *testing.T) {
 		t.Run("pods_run describes denial", func(t *testing.T) {
 			expectedMessage := "failed to run pod  in namespace : resource not allowed: /v1, Kind=Pod"
 			if podsRun.Content[0].(mcp.TextContent).Text != expectedMessage {
-				t.Fatalf("expected desciptive error '%s', got %v", expectedMessage, podsRun.Content[0].(mcp.TextContent).Text)
+				t.Fatalf("expected descriptive error '%s', got %v", expectedMessage, podsRun.Content[0].(mcp.TextContent).Text)
 			}
 		})
 	})

--- a/pkg/mcp/pods_test.go
+++ b/pkg/mcp/pods_test.go
@@ -563,7 +563,6 @@ func TestPodsDelete(t *testing.T) {
 }
 
 func TestPodsDeleteDenied(t *testing.T) {
-	t.Skip("To be implemented") // TODO: delete is not checking for denied resources
 	deniedResourcesServer := &config.StaticConfig{DeniedResources: []config.GroupVersionKind{{Version: "v1", Kind: "Pod"}}}
 	testCaseWithContext(t, &mcpContext{staticConfig: deniedResourcesServer}, func(c *mcpContext) {
 		c.withEnvTest()
@@ -723,7 +722,6 @@ func TestPodsLog(t *testing.T) {
 }
 
 func TestPodsLogDenied(t *testing.T) {
-	t.Skip("To be implemented") // TODO: log is not checking for denied resources
 	deniedResourcesServer := &config.StaticConfig{DeniedResources: []config.GroupVersionKind{{Version: "v1", Kind: "Pod"}}}
 	testCaseWithContext(t, &mcpContext{staticConfig: deniedResourcesServer}, func(c *mcpContext) {
 		c.withEnvTest()
@@ -734,7 +732,7 @@ func TestPodsLogDenied(t *testing.T) {
 			}
 		})
 		t.Run("pods_log describes denial", func(t *testing.T) {
-			expectedMessage := "failed to log pod a-pod-in-default in namespace : resource not allowed: /v1, Kind=Pod"
+			expectedMessage := "failed to get pod a-pod-in-default log in namespace : resource not allowed: /v1, Kind=Pod"
 			if podsLog.Content[0].(mcp.TextContent).Text != expectedMessage {
 				t.Fatalf("expected descriptive error '%s', got %v", expectedMessage, podsLog.Content[0].(mcp.TextContent).Text)
 			}

--- a/pkg/mcp/resources_test.go
+++ b/pkg/mcp/resources_test.go
@@ -169,7 +169,7 @@ func TestResourcesListDenied(t *testing.T) {
 		t.Run("resources_list (denied by kind) describes denial", func(t *testing.T) {
 			expectedMessage := "failed to list resources: resource not allowed: /v1, Kind=Secret"
 			if deniedByKind.Content[0].(mcp.TextContent).Text != expectedMessage {
-				t.Fatalf("expected desciptive error '%s', got %v", expectedMessage, deniedByKind.Content[0].(mcp.TextContent).Text)
+				t.Fatalf("expected descriptive error '%s', got %v", expectedMessage, deniedByKind.Content[0].(mcp.TextContent).Text)
 			}
 		})
 		deniedByGroup, _ := c.callTool("resources_list", map[string]interface{}{"apiVersion": "rbac.authorization.k8s.io/v1", "kind": "Role"})
@@ -181,7 +181,7 @@ func TestResourcesListDenied(t *testing.T) {
 		t.Run("resources_list (denied by group) describes denial", func(t *testing.T) {
 			expectedMessage := "failed to list resources: resource not allowed: rbac.authorization.k8s.io/v1, Kind=Role"
 			if deniedByGroup.Content[0].(mcp.TextContent).Text != expectedMessage {
-				t.Fatalf("expected desciptive error '%s', got %v", expectedMessage, deniedByKind.Content[0].(mcp.TextContent).Text)
+				t.Fatalf("expected descriptive error '%s', got %v", expectedMessage, deniedByKind.Content[0].(mcp.TextContent).Text)
 			}
 		})
 		allowedResource, _ := c.callTool("resources_list", map[string]interface{}{"apiVersion": "v1", "kind": "Namespace"})
@@ -381,7 +381,7 @@ func TestResourcesGetDenied(t *testing.T) {
 		t.Run("resources_get (denied by kind) describes denial", func(t *testing.T) {
 			expectedMessage := "failed to get resource: resource not allowed: /v1, Kind=Secret"
 			if deniedByKind.Content[0].(mcp.TextContent).Text != expectedMessage {
-				t.Fatalf("expected desciptive error '%s', got %v", expectedMessage, deniedByKind.Content[0].(mcp.TextContent).Text)
+				t.Fatalf("expected descriptive error '%s', got %v", expectedMessage, deniedByKind.Content[0].(mcp.TextContent).Text)
 			}
 		})
 		deniedByGroup, _ := c.callTool("resources_get", map[string]interface{}{"apiVersion": "rbac.authorization.k8s.io/v1", "kind": "Role", "namespace": "default", "name": "denied-role"})
@@ -393,7 +393,7 @@ func TestResourcesGetDenied(t *testing.T) {
 		t.Run("resources_get (denied by group) describes denial", func(t *testing.T) {
 			expectedMessage := "failed to get resource: resource not allowed: rbac.authorization.k8s.io/v1, Kind=Role"
 			if deniedByGroup.Content[0].(mcp.TextContent).Text != expectedMessage {
-				t.Fatalf("expected desciptive error '%s', got %v", expectedMessage, deniedByKind.Content[0].(mcp.TextContent).Text)
+				t.Fatalf("expected descriptive error '%s', got %v", expectedMessage, deniedByKind.Content[0].(mcp.TextContent).Text)
 			}
 		})
 		allowedResource, _ := c.callTool("resources_get", map[string]interface{}{"apiVersion": "v1", "kind": "Namespace", "name": "default"})
@@ -601,7 +601,7 @@ func TestResourcesCreateOrUpdateDenied(t *testing.T) {
 		t.Run("resources_create_or_update (denied by kind) describes denial", func(t *testing.T) {
 			expectedMessage := "failed to create or update resources: resource not allowed: /v1, Kind=Secret"
 			if deniedByKind.Content[0].(mcp.TextContent).Text != expectedMessage {
-				t.Fatalf("expected desciptive error '%s', got %v", expectedMessage, deniedByKind.Content[0].(mcp.TextContent).Text)
+				t.Fatalf("expected descriptive error '%s', got %v", expectedMessage, deniedByKind.Content[0].(mcp.TextContent).Text)
 			}
 		})
 		roleYaml := "apiVersion: rbac.authorization.k8s.io/v1\nkind: Role\nmetadata:\n  name: a-denied-role\n  namespace: default\n"
@@ -614,7 +614,7 @@ func TestResourcesCreateOrUpdateDenied(t *testing.T) {
 		t.Run("resources_create_or_update (denied by group) describes denial", func(t *testing.T) {
 			expectedMessage := "failed to create or update resources: resource not allowed: rbac.authorization.k8s.io/v1, Kind=Role"
 			if deniedByGroup.Content[0].(mcp.TextContent).Text != expectedMessage {
-				t.Fatalf("expected desciptive error '%s', got %v", expectedMessage, deniedByKind.Content[0].(mcp.TextContent).Text)
+				t.Fatalf("expected descriptive error '%s', got %v", expectedMessage, deniedByKind.Content[0].(mcp.TextContent).Text)
 			}
 		})
 		configMapYaml := "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: a-cm-created-or-updated\n  namespace: default\n"
@@ -766,7 +766,7 @@ func TestResourcesDeleteDenied(t *testing.T) {
 		t.Run("resources_delete (denied by kind) describes denial", func(t *testing.T) {
 			expectedMessage := "failed to delete resource: resource not allowed: /v1, Kind=Secret"
 			if deniedByKind.Content[0].(mcp.TextContent).Text != expectedMessage {
-				t.Fatalf("expected desciptive error '%s', got %v", expectedMessage, deniedByKind.Content[0].(mcp.TextContent).Text)
+				t.Fatalf("expected descriptive error '%s', got %v", expectedMessage, deniedByKind.Content[0].(mcp.TextContent).Text)
 			}
 		})
 		deniedByGroup, _ := c.callTool("resources_delete", map[string]interface{}{"apiVersion": "rbac.authorization.k8s.io/v1", "kind": "Role", "namespace": "default", "name": "denied-role"})
@@ -778,7 +778,7 @@ func TestResourcesDeleteDenied(t *testing.T) {
 		t.Run("resources_delete (denied by group) describes denial", func(t *testing.T) {
 			expectedMessage := "failed to delete resource: resource not allowed: rbac.authorization.k8s.io/v1, Kind=Role"
 			if deniedByGroup.Content[0].(mcp.TextContent).Text != expectedMessage {
-				t.Fatalf("expected desciptive error '%s', got %v", expectedMessage, deniedByKind.Content[0].(mcp.TextContent).Text)
+				t.Fatalf("expected descriptive error '%s', got %v", expectedMessage, deniedByKind.Content[0].(mcp.TextContent).Text)
 			}
 		})
 		allowedResource, _ := c.callTool("resources_delete", map[string]interface{}{"apiVersion": "v1", "kind": "ConfigMap", "name": "allowed-configmap-to-delete"})


### PR DESCRIPTION
Fixes #132

This approach ensures that resources in the deny list are **always** processed regardless of the implementation.

The RESTMapper takes care of verifying that the requested Group Version Kind complies with the deny list while checking for the REST endpoint.

/cc @ardaguclu