### PR TITLE
Define flags in configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/
+.vscode/
 .docusaurus/
 node_modules/
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,6 +8,15 @@ import (
 
 type StaticConfig struct {
 	DeniedResources []GroupVersionKind `toml:"denied_resources"`
+
+	LogLevel           int    `toml:"log_level,omitempty"`
+	SSEPort            int    `toml:"sse_port,omitempty"`
+	HTTPPort           int    `toml:"http_port,omitempty"`
+	SSEBaseURL         string `toml:"sse_base_url,omitempty"`
+	KubeConfig         string `toml:"kubeconfig,omitempty"`
+	ListOutput         string `toml:"list_output,omitempty"`
+	ReadOnly           bool   `toml:"read_only,omitempty"`
+	DisableDestructive bool   `toml:"disable_destructive,omitempty"`
 }
 
 type GroupVersionKind struct {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -50,6 +50,13 @@ kind = "Role
 
 func TestReadConfigValid(t *testing.T) {
 	validConfigPath := writeConfig(t, `
+log_level = 1
+sse_port = 9999
+kubeconfig = "test"
+list_output = "yaml"
+read_only = true
+disable_destructive = false
+
 [[denied_resources]]
 group = "apps"
 version = "v1"
@@ -77,6 +84,30 @@ version = "v1"
 			config.DeniedResources[0].Version != "v1" ||
 			config.DeniedResources[0].Kind != "Deployment" {
 			t.Errorf("Unexpected denied resources: %v", config.DeniedResources[0])
+		}
+		if config.LogLevel != 1 {
+			t.Fatalf("Unexpected log level: %v", config.LogLevel)
+		}
+		if config.SSEPort != 9999 {
+			t.Fatalf("Unexpected sse_port value: %v", config.SSEPort)
+		}
+		if config.SSEBaseURL != "" {
+			t.Fatalf("Unexpected sse_base_url value: %v", config.SSEBaseURL)
+		}
+		if config.HTTPPort != 0 {
+			t.Fatalf("Unexpected http_port value: %v", config.HTTPPort)
+		}
+		if config.KubeConfig != "test" {
+			t.Fatalf("Unexpected kubeconfig value: %v", config.KubeConfig)
+		}
+		if config.ListOutput != "yaml" {
+			t.Fatalf("Unexpected list_output value: %v", config.ListOutput)
+		}
+		if !config.ReadOnly {
+			t.Fatalf("Unexpected read-only mode: %v", config.ReadOnly)
+		}
+		if config.DisableDestructive {
+			t.Fatalf("Unexpected disable destructive: %v", config.DisableDestructive)
 		}
 	})
 }

--- a/pkg/kubernetes-mcp-server/cmd/root_test.go
+++ b/pkg/kubernetes-mcp-server/cmd/root_test.go
@@ -79,6 +79,54 @@ func TestConfig(t *testing.T) {
 			t.Fatalf("Expected error to be %s, got %s", expected, err.Error())
 		}
 	})
+	t.Run("set with valid --config", func(t *testing.T) {
+		ioStreams, out := testStream()
+		rootCmd := NewMCPServer(ioStreams)
+		_, file, _, _ := runtime.Caller(0)
+		validConfigPath := filepath.Join(filepath.Dir(file), "testdata", "valid-config.toml")
+		rootCmd.SetArgs([]string{"--version", "--config", validConfigPath})
+		_ = rootCmd.Execute()
+		expectedConfig := `(?m)\" - Config\:[^\"]+valid-config\.toml\"`
+		if m, err := regexp.MatchString(expectedConfig, out.String()); !m || err != nil {
+			t.Fatalf("Expected config to be %s, got %s %v", expectedConfig, out.String(), err)
+		}
+		expectedListOutput := `(?m)\" - ListOutput\: yaml"`
+		if m, err := regexp.MatchString(expectedListOutput, out.String()); !m || err != nil {
+			t.Fatalf("Expected config to be %s, got %s %v", expectedListOutput, out.String(), err)
+		}
+		expectedReadOnly := `(?m)\" - Read-only mode: true"`
+		if m, err := regexp.MatchString(expectedReadOnly, out.String()); !m || err != nil {
+			t.Fatalf("Expected config to be %s, got %s %v", expectedReadOnly, out.String(), err)
+		}
+		expectedDisableDestruction := `(?m)\" - Disable destructive tools: true"`
+		if m, err := regexp.MatchString(expectedDisableDestruction, out.String()); !m || err != nil {
+			t.Fatalf("Expected config to be %s, got %s %v", expectedDisableDestruction, out.String(), err)
+		}
+	})
+	t.Run("set with valid --config, flags override", func(t *testing.T) {
+		ioStreams, out := testStream()
+		rootCmd := NewMCPServer(ioStreams)
+		_, file, _, _ := runtime.Caller(0)
+		validConfigPath := filepath.Join(filepath.Dir(file), "testdata", "valid-config.toml")
+		rootCmd.SetArgs([]string{"--version", "--list-output=table", "--disable-destructive=false", "--read-only=false", "--config", validConfigPath})
+		_ = rootCmd.Execute()
+		expected := `(?m)\" - Config\:[^\"]+valid-config\.toml\"`
+		if m, err := regexp.MatchString(expected, out.String()); !m || err != nil {
+			t.Fatalf("Expected config to be %s, got %s %v", expected, out.String(), err)
+		}
+		expectedListOutput := `(?m)\" - ListOutput\: table"`
+		if m, err := regexp.MatchString(expectedListOutput, out.String()); !m || err != nil {
+			t.Fatalf("Expected config to be %s, got %s %v", expectedListOutput, out.String(), err)
+		}
+		expectedReadOnly := `(?m)\" - Read-only mode: false"`
+		if m, err := regexp.MatchString(expectedReadOnly, out.String()); !m || err != nil {
+			t.Fatalf("Expected config to be %s, got %s %v", expectedReadOnly, out.String(), err)
+		}
+		expectedDisableDestruction := `(?m)\" - Disable destructive tools: false"`
+		if m, err := regexp.MatchString(expectedDisableDestruction, out.String()); !m || err != nil {
+			t.Fatalf("Expected config to be %s, got %s %v", expectedDisableDestruction, out.String(), err)
+		}
+	})
 }
 
 func TestProfile(t *testing.T) {

--- a/pkg/kubernetes-mcp-server/cmd/testdata/valid-config.toml
+++ b/pkg/kubernetes-mcp-server/cmd/testdata/valid-config.toml
@@ -1,0 +1,15 @@
+log_level = 1
+sse_port = 9999
+kubeconfig = "test"
+list_output = "yaml"
+read_only = true
+disable_destructive = true
+
+[[denied_resources]]
+group = "apps"
+version = "v1"
+kind = "Deployment"
+
+[[denied_resources]]
+group = "rbac.authorization.k8s.io"
+version = "v1"


### PR DESCRIPTION
This PR adds support of passing flag values in configurations files as described in https://github.com/manusa/kubernetes-mcp-server/issues/137. Flags are always higher priority than the configuration definitions.

This PR fixes https://github.com/manusa/kubernetes-mcp-server/issues/137