### PR TITLE
Introduce enabled/disabled tool list in configuration file

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -11,16 +11,18 @@ import (
 type StaticConfig struct {
 	DeniedResources []GroupVersionKind `toml:"denied_resources"`
 
-	LogLevel           int      `toml:"log_level,omitempty"`
-	SSEPort            int      `toml:"sse_port,omitempty"`
-	HTTPPort           int      `toml:"http_port,omitempty"`
-	SSEBaseURL         string   `toml:"sse_base_url,omitempty"`
-	KubeConfig         string   `toml:"kubeconfig,omitempty"`
-	ListOutput         string   `toml:"list_output,omitempty"`
-	ReadOnly           bool     `toml:"read_only,omitempty"`
+	LogLevel   int    `toml:"log_level,omitempty"`
+	SSEPort    int    `toml:"sse_port,omitempty"`
+	HTTPPort   int    `toml:"http_port,omitempty"`
+	SSEBaseURL string `toml:"sse_base_url,omitempty"`
+	KubeConfig string `toml:"kubeconfig,omitempty"`
+	ListOutput string `toml:"list_output,omitempty"`
+	// When true, expose only tools annotated with readOnlyHint=true
+	ReadOnly bool `toml:"read_only,omitempty"`
+	// When true, disable tools annotated with destructiveHint=true
 	DisableDestructive bool     `toml:"disable_destructive,omitempty"`
-	AllowedTools       []string `toml:"allowed_tools,omitempty"`
-	DeniedTools        []string `toml:"denied_tools,omitempty"`
+	EnabledTools       []string `toml:"enabled_tools,omitempty"`
+	DisabledTools      []string `toml:"disabled_tools,omitempty"`
 }
 
 type GroupVersionKind struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -6,17 +6,21 @@ import (
 	"github.com/BurntSushi/toml"
 )
 
+// StaticConfig is the configuration for the server.
+// It allows to configure server specific settings and tools to be enabled or disabled.
 type StaticConfig struct {
 	DeniedResources []GroupVersionKind `toml:"denied_resources"`
 
-	LogLevel           int    `toml:"log_level,omitempty"`
-	SSEPort            int    `toml:"sse_port,omitempty"`
-	HTTPPort           int    `toml:"http_port,omitempty"`
-	SSEBaseURL         string `toml:"sse_base_url,omitempty"`
-	KubeConfig         string `toml:"kubeconfig,omitempty"`
-	ListOutput         string `toml:"list_output,omitempty"`
-	ReadOnly           bool   `toml:"read_only,omitempty"`
-	DisableDestructive bool   `toml:"disable_destructive,omitempty"`
+	LogLevel           int      `toml:"log_level,omitempty"`
+	SSEPort            int      `toml:"sse_port,omitempty"`
+	HTTPPort           int      `toml:"http_port,omitempty"`
+	SSEBaseURL         string   `toml:"sse_base_url,omitempty"`
+	KubeConfig         string   `toml:"kubeconfig,omitempty"`
+	ListOutput         string   `toml:"list_output,omitempty"`
+	ReadOnly           bool     `toml:"read_only,omitempty"`
+	DisableDestructive bool     `toml:"disable_destructive,omitempty"`
+	AllowedTools       []string `toml:"allowed_tools,omitempty"`
+	DeniedTools        []string `toml:"denied_tools,omitempty"`
 }
 
 type GroupVersionKind struct {
@@ -25,6 +29,7 @@ type GroupVersionKind struct {
 	Kind    string `toml:"kind,omitempty"`
 }
 
+// ReadConfig reads the toml file and returns the StaticConfig.
 func ReadConfig(configPath string) (*StaticConfig, error) {
 	configData, err := os.ReadFile(configPath)
 	if err != nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -57,14 +57,13 @@ list_output = "yaml"
 read_only = true
 disable_destructive = false
 
-[[denied_resources]]
-group = "apps"
-version = "v1"
-kind = "Deployment"
+denied_resources = [
+    {group = "apps", version = "v1", kind = "Deployment"},
+    {group = "rbac.authorization.k8s.io", version = "v1", kind = "Role"}
+]
 
-[[denied_resources]]
-group = "rbac.authorization.k8s.io"
-version = "v1"
+allowed_tools = ["configuration_view", "events_list", "namespaces_list", "pods_list", "resources_list", "resources_get", "resources_create_or_update", "resources_delete"]
+denied_tools = ["pods_delete", "pods_top", "pods_log", "pods_run", "pods_exec"]
 `)
 
 	config, err := ReadConfig(validConfigPath)
@@ -108,6 +107,12 @@ version = "v1"
 		}
 		if config.DisableDestructive {
 			t.Fatalf("Unexpected disable destructive: %v", config.DisableDestructive)
+		}
+		if len(config.AllowedTools) != 8 {
+			t.Fatalf("Unexpected allowed tools: %v", config.AllowedTools)
+		}
+		if len(config.DeniedTools) != 5 {
+			t.Fatalf("Unexpected denied tools: %v", config.DeniedTools)
 		}
 	})
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -62,8 +62,8 @@ denied_resources = [
     {group = "rbac.authorization.k8s.io", version = "v1", kind = "Role"}
 ]
 
-allowed_tools = ["configuration_view", "events_list", "namespaces_list", "pods_list", "resources_list", "resources_get", "resources_create_or_update", "resources_delete"]
-denied_tools = ["pods_delete", "pods_top", "pods_log", "pods_run", "pods_exec"]
+enabled_tools = ["configuration_view", "events_list", "namespaces_list", "pods_list", "resources_list", "resources_get", "resources_create_or_update", "resources_delete"]
+disabled_tools = ["pods_delete", "pods_top", "pods_log", "pods_run", "pods_exec"]
 `)
 
 	config, err := ReadConfig(validConfigPath)
@@ -108,11 +108,11 @@ denied_tools = ["pods_delete", "pods_top", "pods_log", "pods_run", "pods_exec"]
 		if config.DisableDestructive {
 			t.Fatalf("Unexpected disable destructive: %v", config.DisableDestructive)
 		}
-		if len(config.AllowedTools) != 8 {
-			t.Fatalf("Unexpected allowed tools: %v", config.AllowedTools)
+		if len(config.EnabledTools) != 8 {
+			t.Fatalf("Unexpected enabled tools: %v", config.EnabledTools)
 		}
-		if len(config.DeniedTools) != 5 {
-			t.Fatalf("Unexpected denied tools: %v", config.DeniedTools)
+		if len(config.DisabledTools) != 5 {
+			t.Fatalf("Unexpected disabled tools: %v", config.DisabledTools)
 		}
 	})
 }

--- a/pkg/kubernetes-mcp-server/cmd/root.go
+++ b/pkg/kubernetes-mcp-server/cmd/root.go
@@ -186,12 +186,9 @@ func (m *MCPServerOptions) Run() error {
 		return nil
 	}
 	mcpServer, err := mcp.NewServer(mcp.Configuration{
-		Profile:            profile,
-		ListOutput:         listOutput,
-		ReadOnly:           m.StaticConfig.ReadOnly,
-		DisableDestructive: m.StaticConfig.DisableDestructive,
-		Kubeconfig:         m.StaticConfig.KubeConfig,
-		StaticConfig:       m.StaticConfig,
+		Profile:      profile,
+		ListOutput:   listOutput,
+		StaticConfig: m.StaticConfig,
 	})
 	if err != nil {
 		return fmt.Errorf("Failed to initialize MCP server: %w\n", err)

--- a/pkg/kubernetes-mcp-server/cmd/testdata/valid-config.toml
+++ b/pkg/kubernetes-mcp-server/cmd/testdata/valid-config.toml
@@ -5,11 +5,11 @@ list_output = "yaml"
 read_only = true
 disable_destructive = true
 
-[[denied_resources]]
-group = "apps"
-version = "v1"
-kind = "Deployment"
+denied_resources = [
+    {group = "apps", version = "v1", kind = "Deployment"},
+    {group = "rbac.authorization.k8s.io", version = "v1", kind = "Role"}
+]
 
-[[denied_resources]]
-group = "rbac.authorization.k8s.io"
-version = "v1"
+allowed_tools = ["configuration_view", "events_list", "namespaces_list", "pods_list", "resources_list", "resources_get", "resources_create_or_update", "resources_delete"]
+denied_tools = ["pods_delete", "pods_top", "pods_log", "pods_run", "pods_exec"]
+

--- a/pkg/kubernetes-mcp-server/cmd/testdata/valid-config.toml
+++ b/pkg/kubernetes-mcp-server/cmd/testdata/valid-config.toml
@@ -10,6 +10,6 @@ denied_resources = [
     {group = "rbac.authorization.k8s.io", version = "v1", kind = "Role"}
 ]
 
-allowed_tools = ["configuration_view", "events_list", "namespaces_list", "pods_list", "resources_list", "resources_get", "resources_create_or_update", "resources_delete"]
-denied_tools = ["pods_delete", "pods_top", "pods_log", "pods_run", "pods_exec"]
+enabled_tools = ["configuration_view", "events_list", "namespaces_list", "pods_list", "resources_list", "resources_get", "resources_create_or_update", "resources_delete"]
+disabled_tools = ["pods_delete", "pods_top", "pods_log", "pods_run", "pods_exec"]
 

--- a/pkg/mcp/common_test.go
+++ b/pkg/mcp/common_test.go
@@ -4,6 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
 	"github.com/manusa/kubernetes-mcp-server/pkg/config"
 	"github.com/manusa/kubernetes-mcp-server/pkg/output"
 	"github.com/mark3labs/mcp-go/client"
@@ -28,18 +35,12 @@ import (
 	"k8s.io/client-go/tools/clientcmd/api"
 	toolswatch "k8s.io/client-go/tools/watch"
 	"k8s.io/utils/ptr"
-	"net/http/httptest"
-	"os"
-	"path/filepath"
-	"runtime"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/tools/setup-envtest/env"
 	"sigs.k8s.io/controller-runtime/tools/setup-envtest/remote"
 	"sigs.k8s.io/controller-runtime/tools/setup-envtest/store"
 	"sigs.k8s.io/controller-runtime/tools/setup-envtest/versions"
 	"sigs.k8s.io/controller-runtime/tools/setup-envtest/workflows"
-	"testing"
-	"time"
 )
 
 // envTest has an expensive setup, so we only want to do it once per entire test run.
@@ -125,17 +126,18 @@ func (c *mcpContext) beforeEach(t *testing.T) {
 		c.listOutput = output.Yaml
 	}
 	if c.staticConfig == nil {
-		c.staticConfig = &config.StaticConfig{}
+		c.staticConfig = &config.StaticConfig{
+			ReadOnly:           c.readOnly,
+			DisableDestructive: c.disableDestructive,
+		}
 	}
 	if c.before != nil {
 		c.before(c)
 	}
 	if c.mcpServer, err = NewServer(Configuration{
-		Profile:            c.profile,
-		ListOutput:         c.listOutput,
-		ReadOnly:           c.readOnly,
-		DisableDestructive: c.disableDestructive,
-		StaticConfig:       c.staticConfig,
+		Profile:      c.profile,
+		ListOutput:   c.listOutput,
+		StaticConfig: c.staticConfig,
 	}); err != nil {
 		t.Fatal(err)
 		return

--- a/pkg/mcp/common_test.go
+++ b/pkg/mcp/common_test.go
@@ -98,20 +98,19 @@ func TestMain(m *testing.M) {
 }
 
 type mcpContext struct {
-	profile            Profile
-	listOutput         output.Output
-	readOnly           bool
-	disableDestructive bool
-	staticConfig       *config.StaticConfig
-	clientOptions      []transport.ClientOption
-	before             func(*mcpContext)
-	after              func(*mcpContext)
-	ctx                context.Context
-	tempDir            string
-	cancel             context.CancelFunc
-	mcpServer          *Server
-	mcpHttpServer      *httptest.Server
-	mcpClient          *client.Client
+	profile    Profile
+	listOutput output.Output
+
+	staticConfig  *config.StaticConfig
+	clientOptions []transport.ClientOption
+	before        func(*mcpContext)
+	after         func(*mcpContext)
+	ctx           context.Context
+	tempDir       string
+	cancel        context.CancelFunc
+	mcpServer     *Server
+	mcpHttpServer *httptest.Server
+	mcpClient     *client.Client
 }
 
 func (c *mcpContext) beforeEach(t *testing.T) {
@@ -127,8 +126,8 @@ func (c *mcpContext) beforeEach(t *testing.T) {
 	}
 	if c.staticConfig == nil {
 		c.staticConfig = &config.StaticConfig{
-			ReadOnly:           c.readOnly,
-			DisableDestructive: c.disableDestructive,
+			ReadOnly:           false,
+			DisableDestructive: false,
 		}
 	}
 	if c.before != nil {

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -2,8 +2,10 @@ package mcp
 
 import (
 	"context"
-	"github.com/manusa/kubernetes-mcp-server/pkg/config"
 	"net/http"
+	"slices"
+
+	"github.com/manusa/kubernetes-mcp-server/pkg/config"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -64,6 +66,12 @@ func (s *Server) reloadKubernetesClient() error {
 			continue
 		}
 		if s.configuration.DisableDestructive && !ptr.Deref(tool.Tool.Annotations.ReadOnlyHint, false) && ptr.Deref(tool.Tool.Annotations.DestructiveHint, false) {
+			continue
+		}
+		if s.configuration.StaticConfig.AllowedTools != nil && !slices.Contains(s.configuration.StaticConfig.AllowedTools, tool.Tool.Name) {
+			continue
+		}
+		if s.configuration.StaticConfig.DeniedTools != nil && slices.Contains(s.configuration.StaticConfig.DeniedTools, tool.Tool.Name) {
 			continue
 		}
 		applicableTools = append(applicableTools, tool)

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -29,10 +29,10 @@ func (c *Configuration) isToolApplicable(tool server.ServerTool) bool {
 	if c.StaticConfig.DisableDestructive && !ptr.Deref(tool.Tool.Annotations.ReadOnlyHint, false) && ptr.Deref(tool.Tool.Annotations.DestructiveHint, false) {
 		return false
 	}
-	if c.StaticConfig.AllowedTools != nil && !slices.Contains(c.StaticConfig.AllowedTools, tool.Tool.Name) {
+	if c.StaticConfig.EnabledTools != nil && !slices.Contains(c.StaticConfig.EnabledTools, tool.Tool.Name) {
 		return false
 	}
-	if c.StaticConfig.DeniedTools != nil && slices.Contains(c.StaticConfig.DeniedTools, tool.Tool.Name) {
+	if c.StaticConfig.DisabledTools != nil && slices.Contains(c.StaticConfig.DisabledTools, tool.Tool.Name) {
 		return false
 	}
 	return true

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -19,11 +19,6 @@ import (
 type Configuration struct {
 	Profile    Profile
 	ListOutput output.Output
-	// When true, expose only tools annotated with readOnlyHint=true
-	ReadOnly bool
-	// When true, disable tools annotated with destructiveHint=true
-	DisableDestructive bool
-	Kubeconfig         string
 
 	StaticConfig *config.StaticConfig
 }
@@ -55,17 +50,17 @@ func NewServer(configuration Configuration) (*Server, error) {
 }
 
 func (s *Server) reloadKubernetesClient() error {
-	k, err := kubernetes.NewManager(s.configuration.Kubeconfig, s.configuration.StaticConfig)
+	k, err := kubernetes.NewManager(s.configuration.StaticConfig.KubeConfig, s.configuration.StaticConfig)
 	if err != nil {
 		return err
 	}
 	s.k = k
 	applicableTools := make([]server.ServerTool, 0)
 	for _, tool := range s.configuration.Profile.GetTools(s) {
-		if s.configuration.ReadOnly && !ptr.Deref(tool.Tool.Annotations.ReadOnlyHint, false) {
+		if s.configuration.StaticConfig.ReadOnly && !ptr.Deref(tool.Tool.Annotations.ReadOnlyHint, false) {
 			continue
 		}
-		if s.configuration.DisableDestructive && !ptr.Deref(tool.Tool.Annotations.ReadOnlyHint, false) && ptr.Deref(tool.Tool.Annotations.DestructiveHint, false) {
+		if s.configuration.StaticConfig.DisableDestructive && !ptr.Deref(tool.Tool.Annotations.ReadOnlyHint, false) && ptr.Deref(tool.Tool.Annotations.DestructiveHint, false) {
 			continue
 		}
 		if s.configuration.StaticConfig.AllowedTools != nil && !slices.Contains(s.configuration.StaticConfig.AllowedTools, tool.Tool.Name) {

--- a/pkg/mcp/mcp_test.go
+++ b/pkg/mcp/mcp_test.go
@@ -56,7 +56,7 @@ func TestWatchKubeConfig(t *testing.T) {
 }
 
 func TestReadOnly(t *testing.T) {
-	readOnlyServer := func(c *mcpContext) { c.readOnly = true }
+	readOnlyServer := func(c *mcpContext) { c.staticConfig = &config.StaticConfig{ReadOnly: true} }
 	testCaseWithContext(t, &mcpContext{before: readOnlyServer}, func(c *mcpContext) {
 		tools, err := c.mcpClient.ListTools(c.ctx, mcp.ListToolsRequest{})
 		t.Run("ListTools returns tools", func(t *testing.T) {
@@ -245,7 +245,7 @@ func TestIsToolApplicableDeniedTools(t *testing.T) {
 }
 
 func TestDisableDestructive(t *testing.T) {
-	disableDestructiveServer := func(c *mcpContext) { c.disableDestructive = true }
+	disableDestructiveServer := func(c *mcpContext) { c.staticConfig = &config.StaticConfig{DisableDestructive: true} }
 	testCaseWithContext(t, &mcpContext{before: disableDestructiveServer}, func(c *mcpContext) {
 		tools, err := c.mcpClient.ListTools(c.ctx, mcp.ListToolsRequest{})
 		t.Run("ListTools returns tools", func(t *testing.T) {

--- a/pkg/mcp/mcp_test.go
+++ b/pkg/mcp/mcp_test.go
@@ -162,7 +162,7 @@ func TestIsToolApplicableReadOnly(t *testing.T) {
 		{
 			config: Configuration{
 				StaticConfig: &config.StaticConfig{
-					AllowedTools: []string{"namespaces_list"},
+					EnabledTools: []string{"namespaces_list"},
 				},
 			},
 			expected: true,
@@ -175,7 +175,7 @@ func TestIsToolApplicableReadOnly(t *testing.T) {
 		{
 			config: Configuration{
 				StaticConfig: &config.StaticConfig{
-					DeniedTools: []string{"namespaces_list"},
+					DisabledTools: []string{"namespaces_list"},
 				},
 			},
 			expected: false,
@@ -197,10 +197,10 @@ func TestIsToolApplicableReadOnly(t *testing.T) {
 
 }
 
-func TestIsToolApplicableAllowedTools(t *testing.T) {
+func TestIsToolApplicableEnabledTools(t *testing.T) {
 	testCaseWithContext(t, &mcpContext{
 		staticConfig: &config.StaticConfig{
-			AllowedTools: []string{"namespaces_list", "events_list"},
+			EnabledTools: []string{"namespaces_list", "events_list"},
 		},
 	}, func(c *mcpContext) {
 		tools, err := c.mcpClient.ListTools(c.ctx, mcp.ListToolsRequest{})
@@ -209,23 +209,23 @@ func TestIsToolApplicableAllowedTools(t *testing.T) {
 				t.Fatalf("call ListTools failed %v", err)
 			}
 		})
-		t.Run("ListTools does not only return allowed tools", func(t *testing.T) {
+		t.Run("ListTools does not only return enabled tools", func(t *testing.T) {
 			if len(tools.Tools) != 2 {
 				t.Fatalf("ListTools should return 2 tools, got %d", len(tools.Tools))
 			}
 			for _, tool := range tools.Tools {
 				if tool.Name != "namespaces_list" && tool.Name != "events_list" {
-					t.Errorf("Tool %s is not allowed but should be", tool.Name)
+					t.Errorf("Tool %s is not enabled but should be", tool.Name)
 				}
 			}
 		})
 	})
 }
 
-func TestIsToolApplicableDeniedTools(t *testing.T) {
+func TestIsToolApplicableDisabledTools(t *testing.T) {
 	testCaseWithContext(t, &mcpContext{
 		staticConfig: &config.StaticConfig{
-			DeniedTools: []string{"namespaces_list", "events_list"},
+			DisabledTools: []string{"namespaces_list", "events_list"},
 		},
 	}, func(c *mcpContext) {
 		tools, err := c.mcpClient.ListTools(c.ctx, mcp.ListToolsRequest{})
@@ -234,10 +234,10 @@ func TestIsToolApplicableDeniedTools(t *testing.T) {
 				t.Fatalf("call ListTools failed %v", err)
 			}
 		})
-		t.Run("ListTools does not only return allowed tools", func(t *testing.T) {
+		t.Run("ListTools does not only return disabled tools", func(t *testing.T) {
 			for _, tool := range tools.Tools {
 				if tool.Name == "namespaces_list" || tool.Name == "events_list" {
-					t.Errorf("Tool %s is not denied but should be", tool.Name)
+					t.Errorf("Tool %s is not disabled but should be", tool.Name)
 				}
 			}
 		})


### PR DESCRIPTION
Fixes #156 

This PR introduces enabled/disabled tool list in the configuration file. 

Users will be able to add enabled and disabled tools in the configuration file. e.g.

```toml
enabled_tools = ["configuration_view", "events_list", "namespaces_list", "pods_list", "resources_list", "resources_get", "resources_create_or_update", "resources_delete"]
disabled_tools = ["pods_delete", "pods_top", "pods_log", "pods_run", "pods_exec"]
```

This list will be applied to the given profile (full is the default);
* If enabled list is empty, all the tools given in the profile will be populated
* If enabled list is not empty, only the enabled tools will be populated
* If disabled list is not empty, specifically disabled tools will be removed from the tool list.

This PR partially fixes https://github.com/manusa/kubernetes-mcp-server/issues/151

In a follow up PR, I'll add validations to prevent duplicate entries in both enable and disabled list. 