### PR TITLE
Accept standard oauth header by keeping the current header

### DIFF
--- a/pkg/kubernetes/impersonate_roundtripper.go
+++ b/pkg/kubernetes/impersonate_roundtripper.go
@@ -8,7 +8,7 @@ type impersonateRoundTripper struct {
 
 func (irt *impersonateRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	// TODO: Solution won't work with discoveryclient which uses context.TODO() instead of the passed-in context
-	if v, ok := req.Context().Value(AuthorizationHeader).(string); ok {
+	if v, ok := req.Context().Value(OAuthAuthorizationHeader).(string); ok {
 		req.Header.Set("Authorization", v)
 	}
 	return irt.delegate.RoundTrip(req)

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -2,8 +2,9 @@ package kubernetes
 
 import (
 	"context"
-	"k8s.io/apimachinery/pkg/runtime"
 	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/fsnotify/fsnotify"
 
@@ -25,7 +26,8 @@ import (
 )
 
 const (
-	AuthorizationHeader = "kubernetes-authorization"
+	CustomAuthorizationHeader = "kubernetes-authorization"
+	OAuthAuthorizationHeader  = "Authorization"
 )
 
 type CloseWatchKubeConfig func() error
@@ -133,11 +135,11 @@ func (m *Manager) ToRESTMapper() (meta.RESTMapper, error) {
 }
 
 func (m *Manager) Derived(ctx context.Context) *Kubernetes {
-	authorization, ok := ctx.Value(AuthorizationHeader).(string)
+	authorization, ok := ctx.Value(OAuthAuthorizationHeader).(string)
 	if !ok || !strings.HasPrefix(authorization, "Bearer ") {
 		return &Kubernetes{manager: m}
 	}
-	klog.V(5).Infof("%s header found (Bearer), using provided bearer token", AuthorizationHeader)
+	klog.V(5).Infof("%s header found (Bearer), using provided bearer token", OAuthAuthorizationHeader)
 	derivedCfg := rest.CopyConfig(m.cfg)
 	derivedCfg.BearerToken = strings.TrimPrefix(authorization, "Bearer ")
 	derivedCfg.BearerTokenFile = ""

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/manusa/kubernetes-mcp-server/pkg/config"
-	"github.com/manusa/kubernetes-mcp-server/pkg/kubernetes"
+	internalk8s "github.com/manusa/kubernetes-mcp-server/pkg/kubernetes"
 	"github.com/manusa/kubernetes-mcp-server/pkg/output"
 	"github.com/manusa/kubernetes-mcp-server/pkg/version"
 )
@@ -41,7 +41,7 @@ func (c *Configuration) isToolApplicable(tool server.ServerTool) bool {
 type Server struct {
 	configuration *Configuration
 	server        *server.MCPServer
-	k             *kubernetes.Manager
+	k             *internalk8s.Manager
 }
 
 func NewServer(configuration Configuration) (*Server, error) {
@@ -65,7 +65,7 @@ func NewServer(configuration Configuration) (*Server, error) {
 }
 
 func (s *Server) reloadKubernetesClient() error {
-	k, err := kubernetes.NewManager(s.configuration.StaticConfig.KubeConfig, s.configuration.StaticConfig)
+	k, err := internalk8s.NewManager(s.configuration.StaticConfig.KubeConfig, s.configuration.StaticConfig)
 	if err != nil {
 		return err
 	}
@@ -130,5 +130,17 @@ func NewTextResult(content string, err error) *mcp.CallToolResult {
 }
 
 func contextFunc(ctx context.Context, r *http.Request) context.Context {
-	return context.WithValue(ctx, kubernetes.AuthorizationHeader, r.Header.Get(kubernetes.AuthorizationHeader))
+	// Get the standard Authorization header (OAuth compliant)
+	authHeader := r.Header.Get(internalk8s.OAuthAuthorizationHeader)
+	if authHeader != "" {
+		return context.WithValue(ctx, internalk8s.OAuthAuthorizationHeader, authHeader)
+	}
+
+	// Fallback to custom header for backward compatibility
+	customAuthHeader := r.Header.Get(internalk8s.CustomAuthorizationHeader)
+	if customAuthHeader != "" {
+		return context.WithValue(ctx, internalk8s.OAuthAuthorizationHeader, customAuthHeader)
+	}
+
+	return ctx
 }


### PR DESCRIPTION
In order to be OAuth compliant, we'll need to accept bearer tokens from `Authorization` header. This PR passes the token in Authorization header to the context with the same name. 

In order to be backwards compatible, this PR still supports the custom header.