### PR TITLE
Wire static config to Derived object

### DIFF
--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -156,6 +156,7 @@ func (m *Manager) Derived(ctx context.Context) *Kubernetes {
 		Kubeconfig:      m.Kubeconfig,
 		clientCmdConfig: clientcmd.NewDefaultClientConfig(clientCmdApiConfig, nil),
 		cfg:             derivedCfg,
+		staticConfig:    m.staticConfig,
 	}}
 	derived.manager.accessControlClientSet, err = NewAccessControlClientset(derived.manager.cfg, derived.manager.staticConfig)
 	if err != nil {


### PR DESCRIPTION
Since we forgot to wire staticConfig to Derived object, allow/deny resource list is not actually working.

This PR fixes it.