### PR TITLE
Introduce OIDC token verification if authorization-url is specified

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24.1
 
 require (
 	github.com/BurntSushi/toml v1.5.0
+	github.com/coreos/go-oidc/v3 v3.14.1
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/mark3labs/mcp-go v0.33.0
 	github.com/pkg/errors v0.9.1
@@ -51,6 +52,7 @@ require (
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
 	github.com/go-errors/errors v1.4.2 // indirect
 	github.com/go-gorp/gorp/v3 v3.1.0 // indirect
+	github.com/go-jose/go-jose/v4 v4.0.5 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
 github.com/containerd/platforms v0.2.1 h1:zvwtM3rz2YHPQsF2CHYM8+KtB5dvhISiXh5ZpSBQv6A=
 github.com/containerd/platforms v0.2.1/go.mod h1:XHCb+2/hzowdiut9rkudds9bE5yJ7npe7dG/wG+uFPw=
+github.com/coreos/go-oidc/v3 v3.14.1 h1:9ePWwfdwC4QKRlCXsJGou56adA/owXczOzwKdOumLqk=
+github.com/coreos/go-oidc/v3 v3.14.1/go.mod h1:HaZ3szPaZ0e4r6ebqvsLWlk2Tn+aejfmrfah6hnSYEU=
 github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
@@ -92,6 +94,8 @@ github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxI
 github.com/go-errors/errors v1.4.2/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-gorp/gorp/v3 v3.1.0 h1:ItKF/Vbuj31dmV4jxA1qblpSwkl9g1typ24xoe70IGs=
 github.com/go-gorp/gorp/v3 v3.1.0/go.mod h1:dLEjIyyRNiXvNZ8PSmzpt1GsWAUK8kjVhEpjH8TixEw=
+github.com/go-jose/go-jose/v4 v4.0.5 h1:M6T8+mKZl/+fNNuFHvGIzDz7BTLQPIounk/b9dw3AaE=
+github.com/go-jose/go-jose/v4 v4.0.5/go.mod h1:s3P1lRrkT8igV8D9OjyL4WRyHvjB6a4JSllnOrmmBOA=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=

--- a/pkg/http/authorization.go
+++ b/pkg/http/authorization.go
@@ -1,14 +1,15 @@
 package http
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"slices"
 	"strings"
 	"time"
 
+	"github.com/coreos/go-oidc/v3/oidc"
 	"k8s.io/klog/v2"
 
 	"github.com/manusa/kubernetes-mcp-server/pkg/mcp"
@@ -43,7 +44,7 @@ func AuthorizationMiddleware(requireOAuth bool, serverURL string, mcpServer *mcp
 				if serverURL == "" {
 					w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="Kubernetes MCP Server", audience="%s", error="invalid_token"`, audience))
 				} else {
-					w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="Kubernetes MCP Server", audience="%s"", resource_metadata="%s/.well-known/oauth-protected-resource", error="invalid_token"`, audience, serverURL))
+					w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="Kubernetes MCP Server", audience="%s"", resource_metadata="%s%s", error="invalid_token"`, audience, serverURL, oauthProtectedResourceEndpoint))
 				}
 				http.Error(w, "Unauthorized: Bearer token required", http.StatusUnauthorized)
 				return
@@ -51,21 +52,63 @@ func AuthorizationMiddleware(requireOAuth bool, serverURL string, mcpServer *mcp
 
 			token := strings.TrimPrefix(authHeader, "Bearer ")
 
-			err := validateJWTToken(token, audience)
+			// Validate the token offline for simple sanity check
+			// Because missing expected audience and expired tokens must be
+			// rejected already.
+			claims, err := validateJWTToken(token, audience)
 			if err != nil {
 				klog.V(1).Infof("Authentication failed - JWT validation error: %s %s from %s, error: %v", r.Method, r.URL.Path, r.RemoteAddr, err)
 
-				w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="Kubernetes MCP Server", audience=%s, error="invalid_token"`, audience))
+				if serverURL == "" {
+					w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="Kubernetes MCP Server", audience="%s", error="invalid_token"`, audience))
+				} else {
+					w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="Kubernetes MCP Server", audience="%s"", resource_metadata="%s%s", error="invalid_token"`, audience, serverURL, oauthProtectedResourceEndpoint))
+				}
 				http.Error(w, "Unauthorized: Invalid token", http.StatusUnauthorized)
 				return
 			}
 
-			// Validate token using Kubernetes TokenReview API
-			_, _, err = mcpServer.VerifyToken(r.Context(), token, audience)
+			oidcProvider := mcpServer.GetOIDCProvider()
+			if oidcProvider != nil {
+				// If OIDC Provider is configured, this token must be validated against it.
+				if err := validateTokenWithOIDC(r.Context(), oidcProvider, token, audience); err != nil {
+					klog.V(1).Infof("Authentication failed - OIDC token validation error: %s %s from %s, error: %v", r.Method, r.URL.Path, r.RemoteAddr, err)
+
+					if serverURL == "" {
+						w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="Kubernetes MCP Server", audience="%s", error="invalid_token"`, audience))
+					} else {
+						w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="Kubernetes MCP Server", audience="%s"", resource_metadata="%s%s", error="invalid_token"`, audience, serverURL, oauthProtectedResourceEndpoint))
+					}
+					http.Error(w, "Unauthorized: Invalid token", http.StatusUnauthorized)
+					return
+				}
+			}
+
+			// Scopes are likely to be used for authorization.
+			scopes := claims.GetScopes()
+			klog.V(2).Infof("JWT token validated - Scopes: %v", scopes)
+
+			// Now, there are a couple of options:
+			// 1. If there is no authorization url configured for this MCP Server,
+			// that means this token will be used against the Kubernetes API Server.
+			// So that we need to validate the token using Kubernetes TokenReview API beforehand.
+			// 2. If there is an authorization url configured for this MCP Server,
+			// that means up to this point, the token is validated against the OIDC Provider already.
+			// 2. a. If this is the only token in the headers, this validated token
+			// is supposed to be used against the Kubernetes API Server as well. Therefore,
+			// TokenReview request must succeed.
+			// 2. b. If this is not the only token in the headers, the token in here is used
+			// only for authentication and authorization. Therefore, we need to send TokenReview request
+			// with the other token in the headers (TODO: still need to validate aud and exp of this token separately).
+			_, _, err = mcpServer.VerifyTokenAPIServer(r.Context(), token, audience)
 			if err != nil {
 				klog.V(1).Infof("Authentication failed - token validation error: %s %s from %s, error: %v", r.Method, r.URL.Path, r.RemoteAddr, err)
 
-				w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="Kubernetes MCP Server", audience=%s, error="invalid_token"`, audience))
+				if serverURL == "" {
+					w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="Kubernetes MCP Server", audience="%s", error="invalid_token"`, audience))
+				} else {
+					w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="Kubernetes MCP Server", audience="%s"", resource_metadata="%s%s", error="invalid_token"`, audience, serverURL, oauthProtectedResourceEndpoint))
+				}
 				http.Error(w, "Unauthorized: Invalid token", http.StatusUnauthorized)
 				return
 			}
@@ -76,32 +119,60 @@ func AuthorizationMiddleware(requireOAuth bool, serverURL string, mcpServer *mcp
 }
 
 type JWTClaims struct {
-	Issuer    string   `json:"iss"`
-	Audience  []string `json:"aud"`
-	ExpiresAt int64    `json:"exp"`
+	Issuer    string `json:"iss"`
+	Audience  any    `json:"aud"`
+	ExpiresAt int64  `json:"exp"`
+	Scope     string `json:"scope,omitempty"`
 }
 
-// validateJWTToken validates basic JWT claims without signature verification
-func validateJWTToken(token, audience string) error {
+func (c *JWTClaims) GetScopes() []string {
+	if c.Scope == "" {
+		return nil
+	}
+	return strings.Fields(c.Scope)
+}
+
+func (c *JWTClaims) ContainsAudience(audience string) bool {
+	switch aud := c.Audience.(type) {
+	case string:
+		return aud == audience
+	case []interface{}:
+		for _, a := range aud {
+			if str, ok := a.(string); ok && str == audience {
+				return true
+			}
+		}
+	case []string:
+		for _, a := range aud {
+			if a == audience {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// validateJWTToken validates basic JWT claims without signature verification and returns the claims
+func validateJWTToken(token, audience string) (*JWTClaims, error) {
 	parts := strings.Split(token, ".")
 	if len(parts) != 3 {
-		return fmt.Errorf("invalid JWT token format")
+		return nil, fmt.Errorf("invalid JWT token format")
 	}
 
 	claims, err := parseJWTClaims(parts[1])
 	if err != nil {
-		return fmt.Errorf("failed to parse JWT claims: %v", err)
+		return nil, fmt.Errorf("failed to parse JWT claims: %v", err)
 	}
 
 	if claims.ExpiresAt > 0 && time.Now().Unix() > claims.ExpiresAt {
-		return fmt.Errorf("token expired")
+		return nil, fmt.Errorf("token expired")
 	}
 
-	if !slices.Contains(claims.Audience, audience) {
-		return fmt.Errorf("token audience mismatch: %v", claims.Audience)
+	if !claims.ContainsAudience(audience) {
+		return nil, fmt.Errorf("token audience mismatch: %v", claims.Audience)
 	}
 
-	return nil
+	return claims, nil
 }
 
 func parseJWTClaims(payload string) (*JWTClaims, error) {
@@ -121,4 +192,17 @@ func parseJWTClaims(payload string) (*JWTClaims, error) {
 	}
 
 	return &claims, nil
+}
+
+func validateTokenWithOIDC(ctx context.Context, provider *oidc.Provider, token, audience string) error {
+	verifier := provider.Verifier(&oidc.Config{
+		ClientID: audience,
+	})
+
+	_, err := verifier.Verify(ctx, token)
+	if err != nil {
+		return fmt.Errorf("JWT token verification failed: %v", err)
+	}
+
+	return nil
 }

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -16,6 +16,8 @@ import (
 	"github.com/manusa/kubernetes-mcp-server/pkg/mcp"
 )
 
+const oauthProtectedResourceEndpoint = "/.well-known/oauth-protected-resource"
+
 func Serve(ctx context.Context, mcpServer *mcp.Server, staticConfig *config.StaticConfig) error {
 	mux := http.NewServeMux()
 
@@ -36,7 +38,7 @@ func Serve(ctx context.Context, mcpServer *mcp.Server, staticConfig *config.Stat
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
-	mux.HandleFunc("/.well-known/oauth-protected-resource", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(oauthProtectedResourceEndpoint, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 
 		var authServers []string

--- a/pkg/kubernetes-mcp-server/cmd/root.go
+++ b/pkg/kubernetes-mcp-server/cmd/root.go
@@ -22,6 +22,8 @@ import (
 	"github.com/manusa/kubernetes-mcp-server/pkg/mcp"
 	"github.com/manusa/kubernetes-mcp-server/pkg/output"
 	"github.com/manusa/kubernetes-mcp-server/pkg/version"
+
+	_ "github.com/coreos/go-oidc/v3/oidc"
 )
 
 var (

--- a/pkg/kubernetes-mcp-server/cmd/root.go
+++ b/pkg/kubernetes-mcp-server/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -196,20 +197,28 @@ func (m *MCPServerOptions) Validate() error {
 	if !m.StaticConfig.RequireOAuth && (m.StaticConfig.AuthorizationURL != "" || m.StaticConfig.ServerURL != "") {
 		return fmt.Errorf("authorization-url and server-url are only valid if require-oauth is enabled")
 	}
-	if m.StaticConfig.AuthorizationURL != "" &&
-		!strings.HasPrefix(m.StaticConfig.AuthorizationURL, "https://") {
-		if strings.HasPrefix(m.StaticConfig.AuthorizationURL, "http://") {
+	if m.StaticConfig.AuthorizationURL != "" {
+		u, err := url.Parse(m.StaticConfig.AuthorizationURL)
+		if err != nil {
+			return err
+		}
+		if u.Scheme != "https" && u.Scheme != "http" {
+			return fmt.Errorf("--authorization-url must be a valid URL")
+		}
+		if u.Scheme == "http" {
 			klog.Warningf("authorization-url is using http://, this is not recommended production use")
-		} else {
-			return fmt.Errorf("authorization-url must start with https://")
 		}
 	}
-	if m.StaticConfig.ServerURL != "" &&
-		!strings.HasPrefix(m.StaticConfig.ServerURL, "https://") {
-		if strings.HasPrefix(m.StaticConfig.ServerURL, "http://") {
+	if m.StaticConfig.ServerURL != "" {
+		u, err := url.Parse(m.StaticConfig.ServerURL)
+		if err != nil {
+			return err
+		}
+		if u.Scheme != "https" && u.Scheme != "http" {
+			return fmt.Errorf("--server-url must be a valid URL")
+		}
+		if u.Scheme == "http" {
 			klog.Warningf("server-url is using http://, this is not recommended production use")
-		} else {
-			return fmt.Errorf("server-url must start with https://")
 		}
 	}
 	return nil

--- a/pkg/kubernetes-mcp-server/cmd/root_test.go
+++ b/pkg/kubernetes-mcp-server/cmd/root_test.go
@@ -240,7 +240,7 @@ func TestAuthorizationURL(t *testing.T) {
 		if err == nil {
 			t.Fatal("Expected error for invalid authorization-url without protocol, got nil")
 		}
-		expected := "authorization-url must start with https://"
+		expected := "--authorization-url must be a valid URL"
 		if !strings.Contains(err.Error(), expected) {
 			t.Fatalf("Expected error to contain %s, got %s", expected, err.Error())
 		}
@@ -265,7 +265,7 @@ func TestServerURL(t *testing.T) {
 		if err == nil {
 			t.Fatal("Expected error for invalid server-url without protocol, got nil")
 		}
-		expected := "server-url must start with https://"
+		expected := "--server-url must be a valid URL"
 		if !strings.Contains(err.Error(), expected) {
 			t.Fatalf("Expected error to contain %s, got %s", expected, err.Error())
 		}

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"slices"
 
+	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	authenticationapiv1 "k8s.io/api/authentication/v1"
@@ -18,8 +19,9 @@ import (
 )
 
 type Configuration struct {
-	Profile    Profile
-	ListOutput output.Output
+	Profile      Profile
+	ListOutput   output.Output
+	OIDCProvider *oidc.Provider
 
 	StaticConfig *config.StaticConfig
 }

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -107,9 +107,9 @@ func (s *Server) ServeHTTP(httpServer *http.Server) *server.StreamableHTTPServer
 	return server.NewStreamableHTTPServer(s.server, options...)
 }
 
-// VerifyToken verifies the given token with the audience by
+// VerifyTokenAPIServer verifies the given token with the audience by
 // sending an TokenReview request to API Server.
-func (s *Server) VerifyToken(ctx context.Context, token string, audience string) (*authenticationapiv1.UserInfo, []string, error) {
+func (s *Server) VerifyTokenAPIServer(ctx context.Context, token string, audience string) (*authenticationapiv1.UserInfo, []string, error) {
 	if s.k == nil {
 		return nil, nil, fmt.Errorf("kubernetes manager is not initialized")
 	}
@@ -122,6 +122,13 @@ func (s *Server) GetKubernetesAPIServerHost() string {
 		return ""
 	}
 	return s.k.GetAPIServerHost()
+}
+
+func (s *Server) GetOIDCProvider() *oidc.Provider {
+	if s.configuration.OIDCProvider == nil {
+		return nil
+	}
+	return s.configuration.OIDCProvider
 }
 
 func (s *Server) Close() {


### PR DESCRIPTION
This PR is revamped version of https://github.com/manusa/kubernetes-mcp-server/pull/172.

If Authorization URL is set, that means MCP Server is asked to validate the tokens from the given issuer url.

This PR adds support this. Currently, the expectation is to get one token regardless of the authorization url is specified or not. And this token is used against API Server after validated.